### PR TITLE
Corrected xml declaration

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -1,4 +1,4 @@
-<? xml version="1.0" ?>
+<?xml version="1.0"?>
 <rss version="2.0">
 <channel>
 <title>Jamison's Sales and Rental, Inc.</title>


### PR DESCRIPTION
Valid XML declaration requires there to be no spaces after the opening tag and before the closing tag.